### PR TITLE
Add  `__aarch64__` to bituint.h

### DIFF
--- a/src/bituint/bituint.h
+++ b/src/bituint/bituint.h
@@ -137,7 +137,7 @@ static const bituint mask[SIZEUINT] = {
         0x4000000000000000,
         0x8000000000000000
 };
-#elif defined(__arm64__)
+#elif defined(__arm64__) || defined(__aarch64__)
 // ARM64
 typedef uint_fast64_t bituint;
 #define SIZEUINT 64


### PR DESCRIPTION
```
sNMF/../bituint/bituint.h:212:2: error: #error Unsupported architecture
  212 | #error Unsupported architecture
      |  ^~~~~
```
We added the arm64 support since https://github.com/bcm-uga/LEA/commit/835941b2db1782682663f6f127273e5d94f45c01 , but it's no work in Linux aarch64 (Linux arm64) platform.

This patch try to fix the error build on Linux aarch64 (Linux arm64) platform by adding `__aarch64__` process.

[1] Related: https://github.com/Yikun/BBS/issues/11
[2] [Bioc-devel] Support for Linux ARM64: https://stat.ethz.ch/pipermail/bioc-devel/2023-January/019398.html